### PR TITLE
suppress PHP Warning: Invalid argument supplied for foreach() 

### DIFF
--- a/src/VIPSoft/CodeCoverageExtension/Driver/Proxy.php
+++ b/src/VIPSoft/CodeCoverageExtension/Driver/Proxy.php
@@ -55,6 +55,7 @@ class Proxy implements DriverInterface
 
         foreach ($this->drivers as $driver) {
             $coverage = $driver->stop();
+            if (null === $coverage) continue;
 
             foreach ($coverage as $class => $counts) {
                 $aggregate->update($class, $counts);


### PR DESCRIPTION
suppress PHP Warning: Invalid argument supplied for foreach() in vipsoft/code-coverage-extension/src/VIPSoft/CodeCoverageExtension/Driver/Proxy.php on line 59
